### PR TITLE
Fixed a bug causing the Confirmation message sending to fail

### DIFF
--- a/src/ContactFormExtensions.php
+++ b/src/ContactFormExtensions.php
@@ -173,7 +173,7 @@ class ContactFormExtensions extends Plugin
                 $message = new Message();
                 $message->setTo($e->submission->fromEmail);
                 if (isset(App::mailSettings()->fromEmail)) {
-                    $message->setFrom(App::mailSettings()->fromEmail);
+                    $message->setFrom(Craft::parseEnv(App::mailSettings()->fromEmail));
                 } else {
                     $message->setFrom($e->message->getTo());
                 }

--- a/src/ContactFormExtensions.php
+++ b/src/ContactFormExtensions.php
@@ -15,7 +15,6 @@ use Craft;
 use craft\base\Plugin;
 use craft\contactform\events\SendEvent;
 use craft\contactform\Mailer;
-use craft\contactform\models\Submission;
 use craft\events\RegisterUrlRulesEvent;
 use craft\events\TemplateEvent;
 use craft\helpers\App;


### PR DESCRIPTION
This PR resolves issue #72 I opened a few minutes ago.

When the system-wide configuration of “Sender E-mail Address” was done as an environmental variable, that variable wasn’t resolved and the variable name was passed as a “from” e-mail address, which caused SwiftMailer to fail on e-mail addressa format validation.